### PR TITLE
Provided example link to CF Template

### DIFF
--- a/doc_source/aws-config-managed-rules-cloudformation-templates.md
+++ b/doc_source/aws-config-managed-rules-cloudformation-templates.md
@@ -13,7 +13,8 @@ For more information about working with AWS CloudFormation templates, see [Getti
 
 1. For **Specify template**:
    + If you downloaded the template, choose **Upload a template file**, and then **Choose file** to upload the template\.
-   + If you have an Amazon S3 bucket, choose **Amazon S3 URL**, and enter the template URL `https://s3.amazonaws.com/aws-configservice-us-east-1/cloudformation-templates-for-managed-rules/the rule identifier.template`\.
+   + Alternatively you may choose **Amazon S3 URL**, and enter the template URL `https://s3.amazonaws.com/aws-configservice-us-east-1/cloudformation-templates-for-managed-rules/the rule identifier.template`\.
+   ++ Example https://s3.amazonaws.com/aws-configservice-us-east-1/cloudformation-templates-for-managed-rules/CLOUDWATCH_LOG_GROUP_ENCRYPTED.template
 
 1. Choose **Next**\.
 


### PR DESCRIPTION
Wording for S3 Bucket Template Access was confusing and provided no links to an example, instead using the cryptic 'https://s3.amazonaws.com/aws-configservice-us-east-1/cloudformation-templates-for-managed-rules/the rule identifier.template'
as a link example

This is confusing since rule identifiers are in ALL_CAPS_WITH_UNDERSCORES form but the managed rules are in all-lowercase-with-dashes form.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
